### PR TITLE
chore: bump version from 3.0.9 to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump application version from 3.0.9 to 3.1.0.
- This version step aligns with configuration-surface changes around Guestbook environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 3.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->